### PR TITLE
Resolve Ruby 2.7 deprecation warning

### DIFF
--- a/lib/memory_monitor.rb
+++ b/lib/memory_monitor.rb
@@ -6,8 +6,8 @@ class MemoryMonitor
 
   SIGNALS = %w(HUP INT QUIT USR1 USR2 TERM)
 
-  def self.run(*args, **kwargs)
-    new(*args, **kwargs).run
+  def self.run(command, **kwargs)
+    new(command, **kwargs).run
   end
 
   def initialize(command, limit:, timeout: 2, interval: 1)

--- a/lib/memory_monitor.rb
+++ b/lib/memory_monitor.rb
@@ -6,8 +6,8 @@ class MemoryMonitor
 
   SIGNALS = %w(HUP INT QUIT USR1 USR2 TERM)
 
-  def self.run(*args)
-    new(*args).run
+  def self.run(*args, **kwargs)
+    new(*args, **kwargs).run
   end
 
   def initialize(command, limit:, timeout: 2, interval: 1)

--- a/lib/memory_monitor/version.rb
+++ b/lib/memory_monitor/version.rb
@@ -1,3 +1,3 @@
 class MemoryMonitor
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Without this change we get:

```
/usr/local/bundle/gems/memory_monitor-0.1.0/lib/memory_monitor.rb:10: warning:
Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
```